### PR TITLE
Handle piece visuals in tetrisboard

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -6,7 +6,8 @@
 
 #include <iostream>
 
-Game::Game() : m_window{sf::VideoMode(System::WIDTH, System::HEIGHT), "Tetris"}, m_defaultTickLength(1.0f), m_speedTickLength(0.1f), m_tickLength(m_defaultTickLength)
+Game::Game() : m_window{sf::VideoMode(System::WIDTH, System::HEIGHT), "Tetris"}, m_defaultTickLength(1.0f),
+               m_speedTickLength(0.1f), m_currentPiece(NULL), m_tickLength(m_defaultTickLength)
 {
     std::srand(std::time(nullptr));
     SpawnPiece(static_cast<PieceType>(std::rand() % 7));
@@ -16,7 +17,8 @@ void Game::Render()
 {
     m_window.clear();
     m_window.draw(m_board);
-    DrawPieces(m_window);
+    m_window.draw(m_currentPiece);
+    //DrawPieces(m_window);
     m_window.display();
 }
 
@@ -43,13 +45,13 @@ void Game::HandleKeyboardInput(sf::Keyboard::Key keyCode)
     switch(keyCode)
     {
         case sf::Keyboard::Right:
-            if(p_currentPiece && !m_board.WillCollide(MOVE_RIGHT))
+            if(!m_board.WillCollide(MOVE_RIGHT))
             {
                 MovePieceComponents(MOVE_RIGHT);
             }
             break;
         case sf::Keyboard::Left:
-            if(p_currentPiece && !m_board.WillCollide((MOVE_LEFT)))
+            if(!m_board.WillCollide((MOVE_LEFT)))
             {
                 MovePieceComponents(MOVE_LEFT);
             }
@@ -87,28 +89,22 @@ void Game::Run()
 
 void Game::SpawnPiece(PieceType type)
 {
-
-    m_pieces.emplace_back(type);
-    p_currentPiece = &m_pieces.back();
-    int pieceSize = p_currentPiece->GetPieceArray().size();
+    Piece piece(type);
+    m_currentPiece = piece;
+    m_board.currentIsIBlock = type == I_BLOCK;
+    int pieceSize = m_currentPiece.GetPieceArray().size();
     for(int y = 0; y < pieceSize; y++)
     {
         for(int x = 0; x < pieceSize; x++)
         {
-            m_board[y][5+x] = p_currentPiece->GetPieceArray()[y][x] * 2;
+            m_board[y][5+x] = m_currentPiece.GetPieceArray()[y][x] * 2;
 
         }
     }
 
 }
 
-void Game::DrawPieces(sf::RenderWindow &window)
-{
-    for(auto& piece : m_pieces)
-    {
-        window.draw(piece);
-    }
-}
+
 
 void Game::ManageGameClock()
 {
@@ -127,7 +123,7 @@ void Game::Tick()
     //Check collision
     if(!m_board.WillCollide(MOVE_DOWN))
     {
-        p_currentPiece->Fall();
+        m_currentPiece.Fall();
         m_board.FallPiece();
     }else
     {
@@ -142,33 +138,18 @@ void Game::Tick()
 
 void Game::MovePieceComponents(MovementOption direction)
 {
-    p_currentPiece->Move(direction);
+    m_currentPiece.Move(direction);
     m_board.MovePiece(direction);
 }
 
 void Game::RotatePieceComponents(RotationOption direction)
 {
-    p_currentPiece->RotateArray(direction);
-    p_currentPiece->RotateVisual(direction);
+    m_currentPiece.RotateVisual(direction);
     m_board.RotatePiece(direction);
 }
 
 void Game::HandleLineComponents()
 {
     std::vector<int> completedLines = m_board.CheckLines();
-    for(auto lineNum : completedLines)
-    {
-        for(auto & piece : m_pieces)
-        {
-            for(int i = 0; i < 3; i++)
-            {
-                if(piece.GetLevel() + i == lineNum)
-                {
-
-                }
-            }
-        }
-    }
-
 }
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -15,7 +15,7 @@ class Game {
 
 
     sf::RenderWindow m_window;
-    sf::Event m_event;
+    sf::Event m_event{};
     sf::Clock m_clock;
     float m_tickLength;
     float m_defaultTickLength;
@@ -35,14 +35,14 @@ public:
 private:
     //Game objects
     TetrisBoard m_board;
-    std::vector<Piece> m_pieces;
-    Piece* p_currentPiece;
+
+    Piece m_currentPiece;
 
 
 
     //Game functions
     void SpawnPiece(PieceType type);
-    void DrawPieces(sf::RenderWindow& window);
+
     void ManageGameClock();
     void Tick();
     void MovePieceComponents(MovementOption direction);

--- a/src/Piece.cpp
+++ b/src/Piece.cpp
@@ -86,7 +86,7 @@ void Piece::generatePieceVisual()
             {
                 sf::RectangleShape rect(sf::Vector2f(System::PIECE_SIZE, System::PIECE_SIZE));
                 //Since the origin is different for every piece, the position needs to be changed depending on the x/y values
-                rect.setPosition(System::X_OFFSET, System::Y_OFFSET);
+                rect.setPosition(System::X_MIDDLE, System::Y_OFFSET);
                 if(m_type == I_BLOCK)
                 {
                     rect.move(0, -System::PIECE_SIZE);
@@ -143,18 +143,7 @@ void Piece::RotateVisual(RotationOption direction)
 
 }
 
-void Piece::RotateArray(RotationOption direction)
-{
-    PieceArray rotatedArr;
-    for(int i = 0; i < 3; i++)
-    {
-        for(int j = 0; j < 3; j++)
-        {
-            rotatedArr[2-i][j] = m_piece[2-j][2-i];
-        }
-    }
-    m_piece = rotatedArr;
-}
+
 
 const PieceArray & Piece::GetPieceArray() const
 {

--- a/src/Piece.h
+++ b/src/Piece.h
@@ -46,7 +46,7 @@ public:
     void Move(MovementOption direction);
     void Fall();
     void RotateVisual(RotationOption direction);
-    void RotateArray(RotationOption direction);
+
 
     const PieceArray & GetPieceArray() const;
     int GetLevel();

--- a/src/System.h
+++ b/src/System.h
@@ -12,7 +12,8 @@ public:
     static constexpr int WIDTH = 800;
     static constexpr int HEIGHT = 600;
     static constexpr int PIECE_SIZE = 25;
-    static constexpr int X_OFFSET = WIDTH/2 + 10;
+    static constexpr int X_MIDDLE = WIDTH/2 + 10;
+    static constexpr int X_OFFSET = X_MIDDLE - PIECE_SIZE * 6 - PIECE_SIZE/2;
     static constexpr int Y_OFFSET = 85;
 };
 

--- a/src/TetrisBoard.cpp
+++ b/src/TetrisBoard.cpp
@@ -179,10 +179,20 @@ void TetrisBoard::SetPiece()
             if(m_board[y][x] == 2)
             {
                 m_board[y][x] = 1;
+
+                sf::RectangleShape rect(sf::Vector2f(System::PIECE_SIZE, System::PIECE_SIZE));
+                rect.setPosition(System::PIECE_SIZE * x + System::X_OFFSET, System::PIECE_SIZE * (y-1) + System::Y_OFFSET - System::PIECE_SIZE/2);
+                rect.setOutlineColor(sf::Color::Black);
+                rect.setOutlineThickness(1);
+                m_vRect.push_back(rect);
+
+
             }
         }
     }
     m_piecePos = sf::Vector2i(5,0);
+
+
 }
 
 std::vector<int> TetrisBoard::CheckLines()
@@ -245,12 +255,35 @@ void TetrisBoard::ClearLine(const int line)
             }
         }
     }
+
+
+
+    for(int i = 0; i < m_vRect.size(); i++)
+    {
+        if(m_vRect[i].getPosition().y == (line - 1) * System::PIECE_SIZE + System::Y_OFFSET - System::PIECE_SIZE/2)
+        {
+            m_vRect.erase(m_vRect.begin() + i);
+            i--;
+        }
+    }
+    for(auto& rect : m_vRect)
+    {
+        if(rect.getPosition().y < (line - 1) * System::PIECE_SIZE + System::Y_OFFSET - System::PIECE_SIZE/2)
+        {
+            rect.move(0, System::PIECE_SIZE);
+        }
+    }
+
 }
 
 
 void TetrisBoard::draw(sf::RenderTarget &target, sf::RenderStates states) const
 {
     target.draw(m_frame, states);
+    for(auto& i : m_vRect)
+    {
+        target.draw(i);
+    }
 }
 
 const sf::Vector2f & TetrisBoard::getFramePos() const

--- a/src/TetrisBoard.h
+++ b/src/TetrisBoard.h
@@ -25,9 +25,13 @@ class TetrisBoard : public sf::Drawable{
     array<array<uint8_t, 12>,21> m_board;
     sf::RectangleShape m_frame;
     sf::Vector2i m_piecePos;
+    std::vector<sf::RectangleShape> m_vRect;
 
 
 public:
+
+    bool currentIsIBlock;
+
     TetrisBoard();
     void RotatePiece(RotationOption rotation);
     void FallPiece();


### PR DESCRIPTION
Previously, inactive pieces were handled in the game class and were stored in a vector of pieces. This introduced problems when trying to clear lines from the screen, as the rotation and position of the rects in the pieces needed to be synced with the array upon clearing. Now, upon setting of the active piece, individual rects are pushed to a rect vector within the tetrispiece class, which renders with the rest of tetrispiece. Rects pushed to this vector have no recollection of the piece they came from, and have no wierd origin or position issues that they had before. This allows us to clear lines visually extremely easily. 